### PR TITLE
Fix: Image attachments + thread editor optimistically clear

### DIFF
--- a/src/features/messages/component/thread.tsx
+++ b/src/features/messages/component/thread.tsx
@@ -127,22 +127,23 @@ export const Thread = ({ onClose }: ThreadProps) => {
       return;
     }
 
-    try {
-      await createMessage.mutateAsync({
+    createMessage
+      .mutateAsync({
         body: content.body,
         attachments: content.attachments,
         parent_message_id: parentMessage.id,
         thread_id: parentMessage.threadId || parentMessage.id,
         message_type: 'thread',
         plain_text: content.plainText,
+      })
+      .then(() => {
+        setTimeout(() => scrollToBottom(), 100);
+        setEditorKey((prev) => prev + 1);
+      })
+      .catch((error) => {
+        console.error('Failed to send thread reply:', error);
+        toast.error('Failed to send reply. Please try again.');
       });
-
-      setTimeout(() => scrollToBottom(), 100);
-      setEditorKey((prev) => prev + 1);
-    } catch (error) {
-      console.error('Failed to send thread reply:', error);
-      toast.error('Failed to send reply. Please try again.');
-    }
   };
 
   const handleEdit = async (messageId: string, newContent: string) => {


### PR DESCRIPTION
## What

- fix no image attachment download button
- update to use img instead of next/image because of proxy
- optimistically clear thread on send instead of awaiting

## Why

-Not displaying any images because of proxied urls due to private files
-no download button due to tailwind 
-ux update on thread editor

## How

Dont await and instead use then catch to run in background 
Optimise loading and sizing of images and ensure we use html img in order to make request through proxy

## Testing

- [x] Tested locally with `npm run dev`
- [x] Ran quality checks with `npm run check-all`
- [x] Tested in multiple browsers (if UI changes)
- [x] Verified accessibility (if UI changes)

Describe specific testing steps you took.

## Screenshots

<!-- Include before/after screenshots for UI changes -->

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review of the code completed
- [x] Code is properly commented (if complex)
- [ ] Documentation updated (if needed)
- [x] No breaking changes (or clearly documented)
- [ ] Linked related issues (if any)

## Related Issues

<!-- Link related issues using "Fixes #123" or "Closes #123" -->

## Additional Notes

<!-- Any additional context, concerns, or areas where you'd like specific feedback -->
