### PR TITLE
fix: only fetch a single agent conversation

### DIFF
--- a/src/app/[workspace-id]/agents/[agent-id]/page.tsx
+++ b/src/app/[workspace-id]/agents/[agent-id]/page.tsx
@@ -11,10 +11,9 @@ import { useParamIds } from '@/hooks/use-param-ids';
 export default function AgentConversationPage() {
   const { workspaceId, agentId } = useParamIds();
   const router = useRouter();
-
   const { data, isLoading } = useAgentConversations(workspaceId, agentId);
 
-  const conversationId = data?.conversations?.[0]?.id;
+  const conversationId = data?.conversation?.id;
 
   useEffect(() => {
     if (conversationId) {

--- a/src/features/agents/components/agent-conversation-chat.tsx
+++ b/src/features/agents/components/agent-conversation-chat.tsx
@@ -3,6 +3,7 @@
 import { AlertTriangle, Loader } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { toast } from 'sonner';
 
 import { Chat } from '@/components/chat/chat';
 import { transformAgentMessages } from '@/features/agents/helpers';
@@ -18,7 +19,6 @@ import { useToggleReaction } from '@/features/reactions';
 import { useParamIds } from '@/hooks/use-param-ids';
 import { useUIStore } from '@/stores/ui-store';
 import { type Channel, ChannelType } from '@/types/chat';
-import { toast } from 'sonner';
 
 interface AgentConversationChatProps {
   agentId: string;

--- a/src/features/agents/hooks/use-agents.ts
+++ b/src/features/agents/hooks/use-agents.ts
@@ -2,7 +2,7 @@ import { CurrentUser } from '@/features/auth';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { agentsApi } from '../api/agents-api';
 import { agentsQueryKeys } from '../query-keys';
-import { AgentConversationFilters, AgentConversationMessageFilters, AgentFilters } from '../types';
+import { AgentConversationMessageFilters, AgentFilters } from '../types';
 
 export const useAgents = (workspaceId: string, filters?: Partial<AgentFilters>) => {
   return useQuery({
@@ -12,36 +12,11 @@ export const useAgents = (workspaceId: string, filters?: Partial<AgentFilters>) 
   });
 };
 
-export const useAgentConversations = (
-  workspaceId: string,
-  agentId: string,
-  filters?: Partial<AgentConversationFilters>,
-) => {
+export const useAgentConversations = (workspaceId: string, agentId: string) => {
   return useQuery({
-    queryKey: ['agent-conversations', workspaceId, agentId, filters],
-    queryFn: () => agentsApi.getAgentConversations(workspaceId, agentId, filters),
+    queryKey: ['agent-conversations', workspaceId, agentId],
+    queryFn: () => agentsApi.getAgentConversations(workspaceId, agentId),
     enabled: !!workspaceId && !!agentId,
-  });
-};
-
-export const useInfiniteAgentConversations = (
-  workspaceId: string,
-  agentId: string,
-  filters?: Omit<AgentConversationFilters, 'cursor'>,
-) => {
-  return useInfiniteQuery({
-    queryKey: ['agent-conversations-infinite', workspaceId, agentId],
-    queryFn: ({ pageParam }) =>
-      agentsApi.getAgentConversations(workspaceId, agentId, {
-        ...filters,
-        cursor: pageParam,
-      }),
-    initialPageParam: undefined,
-    getNextPageParam: (lastPage) => {
-      return lastPage.pagination.hasMore ? lastPage.pagination.nextCursor : undefined;
-    },
-    enabled: !!workspaceId && !!agentId,
-    staleTime: 1000 * 60 * 60 * 24,
   });
 };
 

--- a/src/features/agents/types.ts
+++ b/src/features/agents/types.ts
@@ -54,12 +54,7 @@ export interface AgentConversationsResponse {
     avatar_url: string | null;
     is_active: boolean;
   };
-  conversations: AgentConversation[];
-  pagination: {
-    limit: number;
-    hasMore: boolean;
-    nextCursor: string | null;
-  };
+  conversation: AgentConversation;
 }
 
 export interface AgentConversationFilters {


### PR DESCRIPTION
## What

Only return 1 agent conversation instead of multiple

## Why

Error with agent conversations fetching multiple instead of just returning 1

## How

Technical approach and implementation details.

## Testing

- [ ] Tested locally with `npm run dev`
- [ ] Ran quality checks with `npm run check-all`
- [ ] Tested in multiple browsers (if UI changes)
- [ ] Verified accessibility (if UI changes)

Describe specific testing steps you took.

## Screenshots

<!-- Include before/after screenshots for UI changes -->

## Checklist

- [ ] Code follows the project's style guidelines
- [ ] Self-review of the code completed
- [ ] Code is properly commented (if complex)
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or clearly documented)
- [ ] Linked related issues (if any)

## Related Issues

<!-- Link related issues using "Fixes #123" or "Closes #123" -->

## Additional Notes

<!-- Any additional context, concerns, or areas where you'd like specific feedback -->
